### PR TITLE
WECHATHY_TOKEN -> WECHATY_PUPPET_SERVICE_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See more at [Wiki:Voice Of Developer](https://github.com/Wechaty/wechaty/wiki/Vo
 ### Ding-dong bot
 
 ```shell
-export WECHATY_TOKEN=<your_token>
+export WECHATY_PUPPET_SERVICE_TOKEN=<your_token>
 export RUST_LOG=<error, warn, info, debug, trace>
 cargo run --example ding-dong-bot
 ```

--- a/examples/ding_dong_bot.rs
+++ b/examples/ding_dong_bot.rs
@@ -8,7 +8,7 @@ use wechaty_puppet_service::PuppetService;
 async fn main() {
     env_logger::init();
     let options = PuppetOptions {
-        endpoint: match env::var("WECHATY_ENDPOINT") {
+        endpoint: match env::var("WECHATY_PUPPET_SERVICE_ENDPOINT") {
             Ok(endpoint) => Some(endpoint),
             Err(_) => None,
         },

--- a/examples/ding_dong_bot.rs
+++ b/examples/ding_dong_bot.rs
@@ -13,7 +13,7 @@ async fn main() {
             Err(_) => None,
         },
         timeout: None,
-        token: match env::var("WECHATY_TOKEN") {
+        token: match env::var("WECHATY_PUPPET_SERVICE_TOKEN") {
             Ok(endpoint) => Some(endpoint),
             Err(_) => None,
         },


### PR DESCRIPTION
We should follow the TS Wechaty & other Polyglot Wechaty naming conventions.

We use `WECHATY_PUPPET_SERVICE_TOKEN` for setting token.