### PR TITLE
feat: add send for room by adding talkable trait

### DIFF
--- a/wechaty-puppet-mock/Cargo.toml
+++ b/wechaty-puppet-mock/Cargo.toml
@@ -10,6 +10,6 @@ keywords = ["chatbot", "wechaty"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "0.11"
+actix = "0.12"
 async-trait = "0.1"
-wechaty_puppet = "0.1.0-beta.1"
+wechaty_puppet = { version = "0.1.0-beta.1", path = "../wechaty-puppet" }

--- a/wechaty-puppet-service/Cargo.toml
+++ b/wechaty-puppet-service/Cargo.toml
@@ -10,16 +10,16 @@ keywords = ["chatbot", "wechaty"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "0.11"
-actix-rt = "2.0"
+actix = "0.12"
+actix-rt = "2"
 async-trait = "0.1"
 log = "0.4"
 num-traits = "0.2"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = "1.2"
+tokio = "1"
 tonic = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
-wechaty_puppet = "0.1.0-beta.1"
+wechaty_puppet = { version = "0.1.0-beta.1", path = "../wechaty-puppet" }
 wechaty-grpc = "0.1"

--- a/wechaty-puppet-service/src/puppet_service.rs
+++ b/wechaty-puppet-service/src/puppet_service.rs
@@ -330,7 +330,7 @@ impl StreamHandler<Result<EventResponse, Status>> for PuppetServiceInner {
                                 data,
                             }));
                         } else {
-                            error!("Reset payload should have string data");
+                            error!("Logout payload should have string data");
                         }
                     }
                     27 => {

--- a/wechaty-puppet/Cargo.toml
+++ b/wechaty-puppet/Cargo.toml
@@ -10,9 +10,9 @@ keywords = ["chatbot", "wechaty"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "0.11"
+actix = "0.12"
 async-trait = "0.1"
-file-box = "0.1.0-beta.0"
+file-box = { version = "0.1.0-beta.0", path = "../file-box" }
 futures = "0.3"
 log = "0.4"
 lru = "0.6"

--- a/wechaty-puppet/src/schemas/friendship.rs
+++ b/wechaty-puppet/src/schemas/friendship.rs
@@ -39,7 +39,7 @@ pub struct FriendshipPayload {
     pub friendship_type: FriendshipType,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct FriendshipSearchQueryFilter {
     pub phone: Option<String>,
     pub weixin: Option<String>,

--- a/wechaty-puppet/src/schemas/message.rs
+++ b/wechaty-puppet/src/schemas/message.rs
@@ -87,7 +87,7 @@ pub struct MessagePayload {
     pub to_id: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct MessageQueryFilter {
     pub from_id: Option<String>,
     pub id: Option<String>,

--- a/wechaty-puppet/src/schemas/room.rs
+++ b/wechaty-puppet/src/schemas/room.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct RoomMemberQueryFilter {
     pub name: Option<String>,
     pub room_alias: Option<String>,
@@ -8,7 +8,7 @@ pub struct RoomMemberQueryFilter {
     pub room_alias_regex: Option<Regex>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct RoomQueryFilter {
     pub id: Option<String>,
     pub topic: Option<String>,

--- a/wechaty/Cargo.toml
+++ b/wechaty/Cargo.toml
@@ -10,18 +10,18 @@ keywords = ["chatbot", "wechaty"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "0.11"
-actix-rt = "2.0"
+actix = "0.12"
+actix-rt = "2"
 async-trait = "0.1"
 futures = "0.3"
 log = "0.4"
-tokio = "1.2"
+tokio = "1"
 tokio-stream = "0.1"
-wechaty_puppet = "0.1.0-beta.1"
+wechaty_puppet = { version = "0.1.0-beta.1", path = "../wechaty-puppet" }
 
 [dev-dependencies]
 env_logger = "0.8"
-wechaty-puppet-service = "0.1.0-beta.1"
+wechaty-puppet-service = { version = "0.1.0-beta.1", path = "../wechaty-puppet-service" }
 
 [[example]]
 name = "ding-dong-bot"

--- a/wechaty/src/context.rs
+++ b/wechaty/src/context.rs
@@ -86,13 +86,7 @@ where
     /// try to fetch from the puppet instead.
     pub(crate) async fn contact_load(&self, contact_id: String) -> Result<Contact<T>, WechatyError> {
         debug!("contact_load(query = {})", contact_id);
-
-        let payload = {
-            match self.contacts().get(&contact_id) {
-                Some(payload) => Some(payload.clone()),
-                None => None,
-            }
-        };
+        let payload = self.contacts().get(&contact_id).cloned();
         match payload {
             Some(payload) => Ok(Contact::new(contact_id.clone(), self.clone(), Some(payload))),
             None => {
@@ -191,12 +185,7 @@ where
     /// try to fetch from the puppet instead.
     pub(crate) async fn message_load(&self, message_id: String) -> Result<Message<T>, WechatyError> {
         debug!("message_load(query = {})", message_id);
-        let payload = {
-            match self.messages().get(&message_id) {
-                Some(payload) => Some(payload.clone()),
-                None => None,
-            }
-        };
+        let payload = self.messages().get(&message_id).cloned();
         match payload {
             Some(payload) => Ok(Message::new(message_id.clone(), self.clone(), Some(payload))),
             None => {
@@ -263,12 +252,7 @@ where
         if !self.is_logged_in() {
             return Err(WechatyError::NotLoggedIn);
         }
-        let payload = {
-            match self.rooms().get(&room_id) {
-                Some(payload) => Some(payload.clone()),
-                None => None,
-            }
-        };
+        let payload = self.rooms().get(&room_id).cloned();
         match payload {
             Some(payload) => Ok(Room::new(room_id.clone(), self.clone(), Some(payload))),
             None => {
@@ -363,12 +347,7 @@ where
         if !self.is_logged_in() {
             return Err(WechatyError::NotLoggedIn);
         }
-        let payload = {
-            match self.friendships().get(&friendship_id) {
-                Some(payload) => Some(payload.clone()),
-                None => None,
-            }
-        };
+        let payload = self.friendships().get(&friendship_id).cloned();
         match payload {
             Some(payload) => Ok(Friendship::new(friendship_id.clone(), self.clone(), Some(payload))),
             None => {

--- a/wechaty/src/lib.rs
+++ b/wechaty/src/lib.rs
@@ -14,6 +14,7 @@ pub use crate::payload::*;
 pub use crate::traits::contact::IntoContact;
 pub use crate::traits::event_listener::EventListener;
 pub(crate) use crate::traits::event_listener::EventListenerInner;
+pub use crate::traits::talkable::Talkable;
 pub use crate::user::contact::Contact;
 pub use crate::user::contact_self::ContactSelf;
 pub(crate) use crate::user::entity::Entity;
@@ -40,6 +41,7 @@ pub mod prelude {
     pub use crate::payload::*;
     pub use crate::traits::contact::IntoContact;
     pub use crate::traits::event_listener::EventListener;
+    pub use crate::traits::talkable::Talkable;
     pub use crate::user::contact::Contact;
     pub use crate::user::contact_self::ContactSelf;
     pub use crate::user::favorite::Favorite;

--- a/wechaty/src/traits/contact.rs
+++ b/wechaty/src/traits/contact.rs
@@ -1,42 +1,14 @@
 use async_trait::async_trait;
-use log::{debug, error, info};
-use wechaty_puppet::{
-    ContactGender, ContactPayload, FileBox, MiniProgramPayload, PayloadType, PuppetImpl, UrlLinkPayload,
-};
+use log::{debug, error};
 
-use crate::{Message, WechatyContext, WechatyError};
-
-async fn message_load<T>(
-    ctx: WechatyContext<T>,
-    message_id: String,
-    identity: String,
-) -> Result<Option<Message<T>>, WechatyError>
-where
-    T: 'static + PuppetImpl + Clone + Unpin + Send + Sync,
-{
-    match ctx.message_load(message_id).await {
-        Ok(message) => {
-            info!("Message sent: {}", message);
-            Ok(Some(message))
-        }
-        Err(e) => {
-            error!(
-                "Message has been sent to {} but cannot get message payload, reason: {}",
-                identity, e
-            );
-            Ok(None)
-        }
-    }
-}
+use crate::{Talkable, WechatyError};
+use wechaty_puppet::{ContactGender, ContactPayload, PayloadType, PuppetImpl};
 
 #[async_trait]
-pub trait IntoContact<T>
+pub trait IntoContact<T>: Talkable<T>
 where
     T: 'static + PuppetImpl + Clone + Unpin + Send + Sync,
 {
-    fn id(&self) -> String;
-    fn ctx(&self) -> WechatyContext<T>;
-    fn identity(&self) -> String;
     fn payload(&self) -> Option<ContactPayload>;
     fn set_payload(&mut self, payload: Option<ContactPayload>);
 
@@ -168,97 +140,5 @@ where
             Some(id) => self.id() == id,
             None => false,
         }
-    }
-
-    async fn send_text(&mut self, text: String) -> Result<Option<Message<T>>, WechatyError> {
-        debug!("contact.send_text(id = {}, text = {})", self.id(), text);
-        let ctx = self.ctx();
-        let puppet = ctx.puppet();
-        let conversation_id = self.id();
-        let message_id = match puppet.message_send_text(conversation_id, text, vec![]).await {
-            Ok(Some(id)) => id,
-            Ok(None) => {
-                error!("Message has been sent to {} but cannot get message id", self.identity());
-                return Ok(None);
-            }
-            Err(e) => return Err(WechatyError::from(e)),
-        };
-        let identity = self.identity();
-        message_load(ctx, message_id, identity).await
-    }
-
-    async fn send_contact(&mut self, contact_id: String) -> Result<Option<Message<T>>, WechatyError> {
-        debug!("contact.send_contact(id = {}, contact_id = {})", self.id(), contact_id);
-        let ctx = self.ctx();
-        let puppet = ctx.puppet();
-        let conversation_id = self.id();
-        let message_id = match puppet.message_send_contact(conversation_id, contact_id).await {
-            Ok(Some(id)) => id,
-            Ok(None) => {
-                error!("Message has been sent to {} but cannot get message id", self.identity());
-                return Ok(None);
-            }
-            Err(e) => return Err(WechatyError::from(e)),
-        };
-        let identity = self.identity();
-        message_load(ctx, message_id, identity).await
-    }
-
-    async fn send_file(&mut self, file: FileBox) -> Result<Option<Message<T>>, WechatyError> {
-        debug!("contact.send_file(id = {})", self.id());
-        let ctx = self.ctx();
-        let puppet = ctx.puppet();
-        let conversation_id = self.id();
-        let message_id = match puppet.message_send_file(conversation_id, file).await {
-            Ok(Some(id)) => id,
-            Ok(None) => {
-                error!("Message has been sent to {} but cannot get message id", self.identity());
-                return Ok(None);
-            }
-            Err(e) => return Err(WechatyError::from(e)),
-        };
-        let identity = self.identity();
-        message_load(ctx, message_id, identity).await
-    }
-
-    async fn send_mini_program(
-        &mut self,
-        mini_program: MiniProgramPayload,
-    ) -> Result<Option<Message<T>>, WechatyError> {
-        debug!(
-            "contact.send_mini_program(id = {}, mini_program = {:?}",
-            self.id(),
-            mini_program
-        );
-        let ctx = self.ctx();
-        let puppet = ctx.puppet();
-        let conversation_id = self.id();
-        let message_id = match puppet.message_send_mini_program(conversation_id, mini_program).await {
-            Ok(Some(id)) => id,
-            Ok(None) => {
-                error!("Message has been sent to {} but cannot get message id", self.identity());
-                return Ok(None);
-            }
-            Err(e) => return Err(WechatyError::from(e)),
-        };
-        let identity = self.identity();
-        message_load(ctx, message_id, identity).await
-    }
-
-    async fn send_url(&mut self, url: UrlLinkPayload) -> Result<Option<Message<T>>, WechatyError> {
-        debug!("contact.send_url(id = {}, url = {:?})", self.id(), url);
-        let ctx = self.ctx();
-        let puppet = ctx.puppet();
-        let conversation_id = self.id();
-        let message_id = match puppet.message_send_url(conversation_id, url).await {
-            Ok(Some(id)) => id,
-            Ok(None) => {
-                error!("Message has been sent to {} but cannot get message id", self.identity());
-                return Ok(None);
-            }
-            Err(e) => return Err(WechatyError::from(e)),
-        };
-        let identity = self.identity();
-        message_load(ctx, message_id, identity).await
     }
 }

--- a/wechaty/src/traits/contact.rs
+++ b/wechaty/src/traits/contact.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use log::{debug, error};
+use wechaty_puppet::{ContactGender, ContactPayload, PayloadType, PuppetImpl};
 
 use crate::{Talkable, WechatyError};
-use wechaty_puppet::{ContactGender, ContactPayload, PayloadType, PuppetImpl};
 
 #[async_trait]
 pub trait IntoContact<T>: Talkable<T>
@@ -51,58 +51,37 @@ where
 
     fn name(&self) -> Option<String> {
         debug!("contact.name(id = {})", self.id());
-        match &self.payload() {
-            Some(payload) => Some(payload.name.clone()),
-            None => None,
-        }
+        self.payload().as_ref().map(|payload| payload.name.clone())
     }
 
     fn gender(&self) -> Option<ContactGender> {
         debug!("contact.gender(id = {})", self.id());
-        match &self.payload() {
-            Some(payload) => Some(payload.gender.clone()),
-            None => None,
-        }
+        self.payload().as_ref().map(|payload| payload.gender.clone())
     }
 
     fn province(&self) -> Option<String> {
         debug!("contact.province(id = {})", self.id());
-        match &self.payload() {
-            Some(payload) => Some(payload.province.clone()),
-            None => None,
-        }
+        self.payload().as_ref().map(|payload| payload.province.clone())
     }
 
     fn city(&self) -> Option<String> {
         debug!("contact.city(id = {})", self.id());
-        match &self.payload() {
-            Some(payload) => Some(payload.city.clone()),
-            None => None,
-        }
+        self.payload().as_ref().map(|payload| payload.city.clone())
     }
 
     fn friend(&self) -> Option<bool> {
         debug!("contact.friend(id = {})", self.id());
-        match &self.payload() {
-            Some(payload) => Some(payload.friend),
-            None => None,
-        }
+        self.payload().as_ref().map(|payload| payload.friend)
     }
 
     fn star(&self) -> Option<bool> {
         debug!("contact.star(id = {})", self.id());
-        match &self.payload() {
-            Some(payload) => Some(payload.star),
-            None => None,
-        }
+        self.payload().as_ref().map(|payload| payload.star)
     }
 
     fn alias(&self) -> Option<String> {
         debug!("contact.alias(id = {})", self.id());
-        match &self.payload() {
-            Some(payload) => Some(payload.alias.clone()),
-            None => None,
-        }
+        self.payload().as_ref().map(|payload| payload.alias.clone())
     }
 
     async fn set_alias(&mut self, new_alias: String) -> Result<(), WechatyError> {

--- a/wechaty/src/traits/mod.rs
+++ b/wechaty/src/traits/mod.rs
@@ -3,9 +3,9 @@ pub(crate) mod event_listener;
 pub(crate) mod talkable;
 
 use log::{error, info};
+use wechaty_puppet::PuppetImpl;
 
 use crate::{Message, WechatyContext, WechatyError};
-use wechaty_puppet::PuppetImpl;
 
 async fn message_load<T>(
     ctx: WechatyContext<T>,

--- a/wechaty/src/traits/mod.rs
+++ b/wechaty/src/traits/mod.rs
@@ -1,2 +1,31 @@
 pub(crate) mod contact;
 pub(crate) mod event_listener;
+pub(crate) mod talkable;
+
+use log::{error, info};
+
+use crate::{Message, WechatyContext, WechatyError};
+use wechaty_puppet::PuppetImpl;
+
+async fn message_load<T>(
+    ctx: WechatyContext<T>,
+    message_id: String,
+    identity: String,
+) -> Result<Option<Message<T>>, WechatyError>
+where
+    T: 'static + PuppetImpl + Clone + Unpin + Send + Sync,
+{
+    match ctx.message_load(message_id).await {
+        Ok(message) => {
+            info!("Message sent: {}", message);
+            Ok(Some(message))
+        }
+        Err(e) => {
+            error!(
+                "Message has been sent to {} but cannot get message payload, reason: {}",
+                identity, e
+            );
+            Ok(None)
+        }
+    }
+}

--- a/wechaty/src/traits/talkable.rs
+++ b/wechaty/src/traits/talkable.rs
@@ -1,10 +1,9 @@
 use async_trait::async_trait;
 use log::{debug, error};
+use wechaty_puppet::{FileBox, MiniProgramPayload, PuppetImpl, UrlLinkPayload};
 
 use super::message_load;
 use crate::{Message, WechatyContext, WechatyError};
-
-use wechaty_puppet::{FileBox, MiniProgramPayload, PuppetImpl, UrlLinkPayload};
 
 #[async_trait]
 pub trait Talkable<T>

--- a/wechaty/src/traits/talkable.rs
+++ b/wechaty/src/traits/talkable.rs
@@ -1,0 +1,106 @@
+use async_trait::async_trait;
+use log::{debug, error};
+
+use super::message_load;
+use crate::{Message, WechatyContext, WechatyError};
+
+use wechaty_puppet::{FileBox, MiniProgramPayload, PuppetImpl, UrlLinkPayload};
+
+#[async_trait]
+pub trait Talkable<T>
+where
+    T: 'static + PuppetImpl + Clone + Unpin + Send + Sync,
+{
+    fn id(&self) -> String;
+    fn ctx(&self) -> WechatyContext<T>;
+    fn identity(&self) -> String;
+
+    async fn send_text(&self, text: String) -> Result<Option<Message<T>>, WechatyError> {
+        debug!("talkable.send_text(id = {}, text = {})", self.id(), text);
+        let ctx = self.ctx();
+        let puppet = ctx.puppet();
+        let conversation_id = self.id();
+        let message_id = match puppet.message_send_text(conversation_id, text, vec![]).await {
+            Ok(Some(id)) => id,
+            Ok(None) => {
+                error!("Message has been sent to {} but cannot get message id", self.identity());
+                return Ok(None);
+            }
+            Err(e) => return Err(WechatyError::from(e)),
+        };
+        let identity = self.identity();
+        message_load(ctx, message_id, identity).await
+    }
+
+    async fn send_contact(&self, contact_id: String) -> Result<Option<Message<T>>, WechatyError> {
+        debug!("talkable.send_contact(id = {}, contact_id = {})", self.id(), contact_id);
+        let ctx = self.ctx();
+        let puppet = ctx.puppet();
+        let conversation_id = self.id();
+        let message_id = match puppet.message_send_contact(conversation_id, contact_id).await {
+            Ok(Some(id)) => id,
+            Ok(None) => {
+                error!("Message has been sent to {} but cannot get message id", self.identity());
+                return Ok(None);
+            }
+            Err(e) => return Err(WechatyError::from(e)),
+        };
+        let identity = self.identity();
+        message_load(ctx, message_id, identity).await
+    }
+
+    async fn send_file(&self, file: FileBox) -> Result<Option<Message<T>>, WechatyError> {
+        debug!("talkable.send_file(id = {})", self.id());
+        let ctx = self.ctx();
+        let puppet = ctx.puppet();
+        let conversation_id = self.id();
+        let message_id = match puppet.message_send_file(conversation_id, file).await {
+            Ok(Some(id)) => id,
+            Ok(None) => {
+                error!("Message has been sent to {} but cannot get message id", self.identity());
+                return Ok(None);
+            }
+            Err(e) => return Err(WechatyError::from(e)),
+        };
+        let identity = self.identity();
+        message_load(ctx, message_id, identity).await
+    }
+
+    async fn send_mini_program(&self, mini_program: MiniProgramPayload) -> Result<Option<Message<T>>, WechatyError> {
+        debug!(
+            "talkable.send_mini_program(id = {}, mini_program = {:?}",
+            self.id(),
+            mini_program
+        );
+        let ctx = self.ctx();
+        let puppet = ctx.puppet();
+        let conversation_id = self.id();
+        let message_id = match puppet.message_send_mini_program(conversation_id, mini_program).await {
+            Ok(Some(id)) => id,
+            Ok(None) => {
+                error!("Message has been sent to {} but cannot get message id", self.identity());
+                return Ok(None);
+            }
+            Err(e) => return Err(WechatyError::from(e)),
+        };
+        let identity = self.identity();
+        message_load(ctx, message_id, identity).await
+    }
+
+    async fn send_url(&self, url: UrlLinkPayload) -> Result<Option<Message<T>>, WechatyError> {
+        debug!("talkable.send_url(id = {}, url = {:?})", self.id(), url);
+        let ctx = self.ctx();
+        let puppet = ctx.puppet();
+        let conversation_id = self.id();
+        let message_id = match puppet.message_send_url(conversation_id, url).await {
+            Ok(Some(id)) => id,
+            Ok(None) => {
+                error!("Message has been sent to {} but cannot get message id", self.identity());
+                return Ok(None);
+            }
+            Err(e) => return Err(WechatyError::from(e)),
+        };
+        let identity = self.identity();
+        message_load(ctx, message_id, identity).await
+    }
+}

--- a/wechaty/src/user/contact.rs
+++ b/wechaty/src/user/contact.rs
@@ -4,7 +4,7 @@ use log::{debug, trace};
 use wechaty_puppet::{ContactPayload, PuppetImpl};
 
 use crate::user::entity::Entity;
-use crate::{IntoContact, WechatyContext};
+use crate::{IntoContact, Talkable, WechatyContext};
 
 pub type Contact<T> = Entity<T, ContactPayload>;
 
@@ -29,7 +29,7 @@ where
     }
 }
 
-impl<T> IntoContact<T> for Contact<T>
+impl<T> Talkable<T> for Contact<T>
 where
     T: 'static + PuppetImpl + Clone + Unpin + Send + Sync,
 {
@@ -60,7 +60,12 @@ where
             None => "loading...".to_owned(),
         }
     }
+}
 
+impl<T> IntoContact<T> for Contact<T>
+where
+    T: 'static + PuppetImpl + Clone + Unpin + Send + Sync,
+{
     fn payload(&self) -> Option<ContactPayload> {
         trace!("Contact.payload(id = {})", self.id_);
         self.payload_.clone()

--- a/wechaty/src/user/contact.rs
+++ b/wechaty/src/user/contact.rs
@@ -16,10 +16,7 @@ where
         debug!("create contact {}", id);
         let payload = match payload {
             Some(_) => payload,
-            None => match ctx.contacts().get(&id) {
-                Some(payload) => Some(payload.clone()),
-                None => None,
-            },
+            None => ctx.contacts().get(&id).cloned(),
         };
         Self {
             id_: id,

--- a/wechaty/src/user/contact_self.rs
+++ b/wechaty/src/user/contact_self.rs
@@ -21,10 +21,7 @@ where
         debug!("create contact self {}", id);
         let payload = match payload {
             Some(_) => payload,
-            None => match ctx.contacts().get(&id) {
-                Some(payload) => Some(payload.clone()),
-                None => None,
-            },
+            None => ctx.contacts().get(&id).cloned(),
         };
         Self {
             contact: Contact::new(id, ctx, payload),

--- a/wechaty/src/user/contact_self.rs
+++ b/wechaty/src/user/contact_self.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use log::{debug, error};
 use wechaty_puppet::{ContactPayload, FileBox, PuppetImpl};
 
-use crate::{Contact, IntoContact, WechatyContext, WechatyError};
+use crate::{Contact, IntoContact, Talkable, WechatyContext, WechatyError};
 
 #[derive(Clone)]
 pub struct ContactSelf<T>
@@ -113,7 +113,7 @@ where
     }
 }
 
-impl<T> IntoContact<T> for ContactSelf<T>
+impl<T> Talkable<T> for ContactSelf<T>
 where
     T: 'static + PuppetImpl + Clone + Unpin + Send + Sync,
 {
@@ -128,7 +128,12 @@ where
     fn identity(&self) -> String {
         self.contact.identity()
     }
+}
 
+impl<T> IntoContact<T> for ContactSelf<T>
+where
+    T: 'static + PuppetImpl + Clone + Unpin + Send + Sync,
+{
     fn payload(&self) -> Option<ContactPayload> {
         self.contact.payload()
     }

--- a/wechaty/src/user/friendship.rs
+++ b/wechaty/src/user/friendship.rs
@@ -15,10 +15,7 @@ where
         debug!("create friendship {}", id);
         let payload = match payload {
             Some(_) => payload,
-            None => match ctx.friendships().get(&id) {
-                Some(payload) => Some(payload.clone()),
-                None => None,
-            },
+            None => ctx.friendships().get(&id).cloned(),
         };
         Self {
             id_: id,
@@ -53,10 +50,7 @@ where
     /// Get friendship's type.
     pub fn friendship_type(&self) -> Option<FriendshipType> {
         debug!("Friendship.friendship_type(id = {})", self.id_);
-        match &self.payload_ {
-            Some(payload) => Some(payload.friendship_type.clone()),
-            None => None,
-        }
+        self.payload_.as_ref().map(|payload| payload.friendship_type.clone())
     }
 
     /// Get friendship's contact.

--- a/wechaty/src/user/message.rs
+++ b/wechaty/src/user/message.rs
@@ -4,7 +4,7 @@ use std::time::SystemTime;
 use log::{debug, error, info};
 use wechaty_puppet::{FileBox, MessagePayload, MessageType, MiniProgramPayload, PuppetImpl, UrlLinkPayload};
 
-use crate::{Contact, Entity, IntoContact, Room, WechatyContext, WechatyError};
+use crate::{Contact, Entity, IntoContact, Room, Talkable, WechatyContext, WechatyError};
 
 pub type Message<T> = Entity<T, MessagePayload>;
 

--- a/wechaty/src/user/message.rs
+++ b/wechaty/src/user/message.rs
@@ -16,10 +16,7 @@ where
         debug!("create message {}", id);
         let payload = match payload {
             Some(_) => payload,
-            None => match ctx.messages().get(&id) {
-                Some(payload) => Some(payload.clone()),
-                None => None,
-            },
+            None => ctx.messages().get(&id).cloned(),
         };
         Self {
             id_: id,
@@ -151,10 +148,7 @@ where
     /// Get message's timestamp.
     pub fn timestamp(&self) -> Option<u64> {
         debug!("Message.timestamp(id = {})", self.id_);
-        match &self.payload_ {
-            Some(payload) => Some(payload.timestamp),
-            None => None,
-        }
+        self.payload_.as_ref().map(|payload| payload.timestamp)
     }
 
     /// Get message's age in seconds.
@@ -176,19 +170,13 @@ where
     /// Get the message type.
     pub fn message_type(&self) -> Option<MessageType> {
         debug!("Message.message_type(id = {})", self.id_);
-        match &self.payload_ {
-            Some(payload) => Some(payload.message_type.clone()),
-            None => None,
-        }
+        self.payload_.as_ref().map(|payload| payload.message_type.clone())
     }
 
     /// Get the message's text content, if it is a text message.
     pub fn text(&self) -> Option<String> {
         debug!("Message.text(id = {})", self.id_);
-        match &self.payload_ {
-            Some(payload) => Some(payload.text.clone()),
-            None => None,
-        }
+        self.payload_.as_ref().map(|payload| payload.text.clone())
     }
 
     /// Get the trimmed version (no mentions) of the message's text content.

--- a/wechaty/src/user/room.rs
+++ b/wechaty/src/user/room.rs
@@ -16,10 +16,7 @@ where
         debug!("create room {}", id);
         let payload = match payload {
             Some(_) => payload,
-            None => match ctx.rooms().get(&id) {
-                Some(payload) => Some(payload.clone()),
-                None => None,
-            },
+            None => ctx.rooms().get(&id).cloned(),
         };
         Self {
             id_: id,

--- a/wechaty/src/user/room_invitation.rs
+++ b/wechaty/src/user/room_invitation.rs
@@ -15,10 +15,7 @@ where
         debug!("create room invitation {}", id);
         let payload = match payload {
             Some(_) => payload,
-            None => match ctx.room_invitations().get(&id) {
-                Some(payload) => Some(payload.clone()),
-                None => None,
-            },
+            None => ctx.room_invitations().get(&id).cloned(),
         };
         Self {
             id_: id,

--- a/wechaty/src/wechaty.rs
+++ b/wechaty/src/wechaty.rs
@@ -22,7 +22,7 @@ where
     pub fn new(puppet: Puppet<T>) -> Self {
         let listener = EventListenerInner::new("Wechaty".to_owned(), WechatyContext::new(puppet.clone()));
         let addr = listener.clone().start();
-        Self { puppet, addr, listener }
+        Self { puppet, listener, addr }
     }
 
     pub async fn start(&self) {


### PR DESCRIPTION
通过增加一个 `Talkable` trait 给 `Room` 增加了 `send_xxx` 系列方法，复用的 `Contract` 里的实现。

因为不知道 wechaty 的具体架构和协议，不太确定有没有问题，测试了 `room.send_text` 是没问题的。

另外不知道是客户端这边实现确实不对，还是 `wechaty-puppet-wechat` 实现有问题，用 `wechaty` docker 镜像 0.63 版本作为 puppet，扫码登录时会发一个 `Heartbeat` 类型的消息过来，但是 `data` 字段是个 `Object`（而不是代码里定义的 `String`），会导致 panic，这里顺便修复了下。

还有点小修改，比如给 `QueryFilter` 类型都加上了 `Default` trait 方便构造 filter。

---

以下是 `Heartbeat` 的 `data` 为 `Object` 的 Log：

![](https://user-images.githubusercontent.com/7822577/122327489-83cd1e00-cf60-11eb-8823-4b15379d7bd2.png)